### PR TITLE
Bump v0.1.5 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
 name = "echo"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.4
+version: 0.1.5
 name: echo
 displayName: Echo
-createdAt: 2023-03-21T12:20:44.502324259Z
+createdAt: 2023-07-07T18:31:36.346562422Z
 description: A policy that echoes back Kubernetes' AdmissionReview - useful for Policy Authors
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/echo
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/echo:v0.1.4
+  image: ghcr.io/kubewarden/policies/echo:v0.1.5
 keywords:
 - developer
 links:
 - name: policy
-  url: https://github.com/kubewarden/echo/releases/download/v0.1.4/policy.wasm
+  url: https://github.com/kubewarden/echo/releases/download/v0.1.5/policy.wasm
 - name: source
   url: https://github.com/kubewarden/echo
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/echo:v0.1.4
+  kwctl pull ghcr.io/kubewarden/policies/echo:v0.1.5
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.5 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.5

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
