### PR TITLE
feat: Make policy loop with `io.kubewarden.policy.echo.loop` annot

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ will contain the JSON representation of the the `AdmissionReview`.
 
 These are the annotations being watched:
 
-* `io.kubewarden.policy.echo.create`: rejects creation of objects with this annotations
-* `io.kubewarden.policy.echo.updates`: rejects changes to objects with this annotations
-* `io.kubewarden.policy.echo.delete`: rejects deletions of objects with this annotations
-* `io.kubewarden.policy.echo.connect`: rejects CONNECT operations to objects with this annotations
+- `io.kubewarden.policy.echo.create`: rejects creation of objects with this annotations
+- `io.kubewarden.policy.echo.updates`: rejects changes to objects with this annotations
+- `io.kubewarden.policy.echo.delete`: rejects deletions of objects with this annotations
+- `io.kubewarden.policy.echo.connect`: rejects CONNECT operations to objects with this annotations
+- `io.kubewarden.policy.echo.loop`: the policy loops. This will result in a
+  rejection as the policy-server timeout is reached and it fails-closed.
 
-We will cover these in depth inside of the *"examples"* section.
+We will cover these in depth inside of the _"examples"_ section.
 
 ## Settings
 
@@ -95,10 +97,10 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:latest
-        ports:
-        - containerPort: 80
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
 ```
 
 Attempting to create this object will fail because the `echo` policy rejects

--- a/test_data/create_loop.json
+++ b/test_data/create_loop.json
@@ -1,0 +1,166 @@
+{
+  "dryRun": false,
+  "kind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "annotations": {
+        "io.kubewarden.policy.echo.loop": "true",
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":0,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:latest\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
+      },
+      "creationTimestamp": "2022-06-22T13:23:21Z",
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "apps/v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:io.kubewarden.policy.echo.create": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              "f:progressDeadlineSeconds": {},
+              "f:replicas": {},
+              "f:revisionHistoryLimit": {},
+              "f:selector": {},
+              "f:strategy": {
+                "f:rollingUpdate": {
+                  ".": {},
+                  "f:maxSurge": {},
+                  "f:maxUnavailable": {}
+                },
+                "f:type": {}
+              },
+              "f:template": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:app": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2022-06-22T13:23:21Z"
+        }
+      ],
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "5be2582c-c8fb-4318-8d47-6df8a24affc7"
+    },
+    "spec": {
+      "progressDeadlineSeconds": 600,
+      "replicas": 0,
+      "revisionHistoryLimit": 10,
+      "selector": {
+        "matchLabels": {
+          "app": "nginx"
+        }
+      },
+      "strategy": {
+        "rollingUpdate": {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%"
+        },
+        "type": "RollingUpdate"
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "nginx"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx:latest",
+              "imagePullPolicy": "Always",
+              "name": "nginx",
+              "ports": [
+                {
+                  "containerPort": 80,
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  "operation": "CREATE",
+  "options": {
+    "apiVersion": "meta.k8s.io/v1",
+    "fieldManager": "kubectl-client-side-apply",
+    "kind": "CreateOptions"
+  },
+  "requestKind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "requestResource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "uid": "307362f8-ffb1-481a-9ce7-7e6192fbc699",
+  "userInfo": {
+    "groups": ["system:masters", "system:authenticated"],
+    "username": "minikube-user"
+  }
+}


### PR DESCRIPTION
## Description

Add a new `Operation::Loop`, that corresponds to
`io.kubewarden.policy.echo.loop` annotation.

When this annotation is present, the policy will loop indifinetly. This is helpful for testing purposes.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
